### PR TITLE
Seek after Player Ready

### DIFF
--- a/src/js/cast/mediamanager.js
+++ b/src/js/cast/mediamanager.js
@@ -1007,11 +1007,15 @@ export default function JWMediaManager(receiverManager, container, events, analy
 
             mediaStatus.currentTime = 0;
             if ((item.startTimeOverride || item.startTime) && item.streamType != 'LIVE') {
-            // TODO: Check for live.
+                // TODO: Check for live.
                 let startTime = item.startTimeOverride ? item.startTimeOverride : item.startTime;
+
                 mediaStatus.currentTime = startTime;
-                playerInstance.seek(startTime);
-            // The startTime can only be overridden once.
+                playerInstance.once('ready', function() {
+                    playerInstance.seek(startTime);
+                });
+
+                // The startTime can only be overridden once.
                 delete item.startTimeOverride;
             }
 


### PR DESCRIPTION
So when starting to cast while playing a stream, we were trying to seek
before jwplayer completed setup. Seek now occurs once the payer is
ready.

JW7-4195