### PR TITLE
Player stuck buffering for live streams

### DIFF
--- a/src/js/cast/mediamanager.js
+++ b/src/js/cast/mediamanager.js
@@ -1061,13 +1061,14 @@ export default function JWMediaManager(receiverManager, container, events, analy
             } else {
                 // Listen for the 'meta' event in order the duration
                 // before playback begins.
-                playerInstance.once('meta', event => {
-                    if (!event.duration) {
-                        return;
+                const onMeta = event => {
+                    if (event.duration >= 0) {
+                        playerInstance.off('meta', onMeta);
+                        mediaStatus.media.duration = event.duration;
+                        resolve();
                     }
-                    mediaStatus.media.duration = event.duration;
-                    resolve();
-                });
+                };
+                playerInstance.on('meta', onMeta);
             }
         });
     }

--- a/src/js/cast/mediamanager.js
+++ b/src/js/cast/mediamanager.js
@@ -1062,10 +1062,11 @@ export default function JWMediaManager(receiverManager, container, events, analy
                 // Listen for the 'meta' event in order the duration
                 // before playback begins.
                 playerInstance.once('meta', event => {
-                    if (event.duration) {
-                        mediaStatus.media.duration = event.duration;
-                        resolve();
+                    if (!event.duration) {
+                        return;
                     }
+                    mediaStatus.media.duration = event.duration;
+                    resolve();
                 });
             }
         });

--- a/src/js/cast/mediamanager.js
+++ b/src/js/cast/mediamanager.js
@@ -1062,8 +1062,10 @@ export default function JWMediaManager(receiverManager, container, events, analy
                 // Listen for the 'meta' event in order the duration
                 // before playback begins.
                 playerInstance.once('meta', event => {
-                    mediaStatus.media.duration = event.duration;
-                    resolve();
+                    if (event.duration) {
+                        mediaStatus.media.duration = event.duration;
+                        resolve();
+                    }
                 });
             }
         });

--- a/src/js/cast/mediamanager.js
+++ b/src/js/cast/mediamanager.js
@@ -1061,14 +1061,15 @@ export default function JWMediaManager(receiverManager, container, events, analy
             } else {
                 // Listen for the 'meta' event in order the duration
                 // before playback begins.
-                const onMeta = event => {
+                const onDuration = event => {
+                    console.log('onDuration');
                     if (event.duration >= 0) {
-                        playerInstance.off('meta', onMeta);
+                        playerInstance.off('meta time', onDuration);
                         mediaStatus.media.duration = event.duration;
                         resolve();
                     }
                 };
-                playerInstance.on('meta', onMeta);
+                playerInstance.on('meta time', onDuration);
             }
         });
     }

--- a/src/js/cast/mediamanager.js
+++ b/src/js/cast/mediamanager.js
@@ -966,7 +966,7 @@ export default function JWMediaManager(receiverManager, container, events, analy
      */
     function loadItem(item) {
         return new Promise((resolve, reject) => {
-                // Broadcast a MEDIA_LOAD event.
+            // Broadcast a MEDIA_LOAD event.
             events.publish(Events.MEDIA_LOAD, {
                 item: item
             });
@@ -1045,7 +1045,7 @@ export default function JWMediaManager(receiverManager, container, events, analy
             playerInstance.once('setupError', reject);
             playerInstance.once('error', reject);
             if (mediaStatus.media.duration) {
-            // Update ad break info before resolving.
+                // Update ad break info before resolving.
                 initAdBreakInfo(media);
             }
 
@@ -1055,13 +1055,13 @@ export default function JWMediaManager(receiverManager, container, events, analy
             });
 
             if (hasPreRoll && !mediaStatus.media.duration) {
-            // It is impossible to determine the duration
-            // before playback.
+                // It is impossible to determine the duration
+                // before playback.
                 resolve();
             } else {
-            // Listen for the 'bufferChange' event in order the duration
-            // before playback begins.
-                playerInstance.once('bufferChange', event => {
+                // Listen for the 'meta' event in order the duration
+                // before playback begins.
+                playerInstance.once('meta', event => {
                     mediaStatus.media.duration = event.duration;
                     resolve();
                 });


### PR DESCRIPTION
Receiver was waiting for a `bufferChange` event to update the duration
and state, which does not occur with live streams. Replaced with `meta`
instead.

JW7-4207